### PR TITLE
Set application to fullscreen and disable window frame in kiosk mode

### DIFF
--- a/src/apps/kiosk-q/src/main.ts
+++ b/src/apps/kiosk-q/src/main.ts
@@ -14,6 +14,7 @@ const createWindow = () => {
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
     },
+    frame: false,
   });
 
   const KIOSK_SERVER_URL = process.env.KIOSK_SERVER_URL;
@@ -31,6 +32,8 @@ const createWindow = () => {
 
   // Open the DevTools.
   // mainWindow.webContents.openDevTools();
+
+  mainWindow.setFullScreen(true);
 };
 
 // This method will be called when Electron has finished


### PR DESCRIPTION
Configure the application to run in fullscreen and disable the window frame when in kiosk mode.