### PR TITLE
Fix make app error in some machine

### DIFF
--- a/src/apps/kiosk-q/package.json
+++ b/src/apps/kiosk-q/package.json
@@ -20,6 +20,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "^7.5.0",
     "@electron-forge/plugin-fuses": "^7.5.0",
     "@electron-forge/plugin-vite": "^7.5.0",
+    "@electron-forge/shared-types": "^7.5.0",
     "@electron/fuses": "^1.8.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/src/pnpm-lock.yaml
+++ b/src/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@electron-forge/plugin-vite':
         specifier: ^7.5.0
         version: 7.5.0
+      '@electron-forge/shared-types':
+        specifier: ^7.5.0
+        version: 7.5.0
       '@electron/fuses':
         specifier: ^1.8.0
         version: 1.8.0


### PR DESCRIPTION
Add the @electron-forge/shared-types dependency to package.json and pnpm-lock.yaml to ensure compatibility with shared types in the project.