### PR TITLE
Bump version and description in package.json for kiosk-q application

### DIFF
--- a/src/apps/kiosk-q/package.json
+++ b/src/apps/kiosk-q/package.json
@@ -1,8 +1,8 @@
 {
   "name": "kiosk-q",
   "productName": "kiosk-q",
-  "version": "1.0.0",
-  "description": "My Electron application description",
+  "version": "0.1.0",
+  "description": "The Kiosk for Queue System",
   "main": ".vite/build/main.js",
   "scripts": {
     "start": "electron-forge start",


### PR DESCRIPTION
Change the version to 0.1.0 and update the application description to reflect its purpose as the Kiosk for Queue System.